### PR TITLE
Optimize AtomicListReference by not updating the list if result is the same

### DIFF
--- a/foundation/src/commonMain/kotlin/com/mirego/trikot/foundation/concurrent/AtomicListReference.kt
+++ b/foundation/src/commonMain/kotlin/com/mirego/trikot/foundation/concurrent/AtomicListReference.kt
@@ -27,6 +27,9 @@ class AtomicListReference<T> {
         do {
             oldList = value
             newList = block(oldList)
+            if (oldList == newList) {
+                return oldList
+            }
         } while (!internalReference.compareAndSet(oldList, newList))
 
         return newList


### PR DESCRIPTION
Make sure to not store a new list in the internal AtomicReference if list is not change after block execution.