### PR TITLE
Add ability to add some debug information to atomic reference

### DIFF
--- a/foundation/src/commonMain/kotlin/com/mirego/trikot/foundation/concurrent/AtomicReference.kt
+++ b/foundation/src/commonMain/kotlin/com/mirego/trikot/foundation/concurrent/AtomicReference.kt
@@ -7,5 +7,7 @@ expect class AtomicReference<T>(value: T) {
 
     fun setOrThrow(expected: T, new: T)
 
+    fun setOrThrow(expected: T, new: T, debugInfo: (() -> String)?)
+
     fun compareAndSwap(expected: T, new: T): T
 }

--- a/foundation/src/jsMain/kotlin/com/mirego/trikot/foundation/concurrent/AtomicReference.kt
+++ b/foundation/src/jsMain/kotlin/com/mirego/trikot/foundation/concurrent/AtomicReference.kt
@@ -11,6 +11,10 @@ actual class AtomicReference<T> actual constructor(value: T) {
     }
 
     actual fun setOrThrow(expected: T, new: T) {
+        setOrThrow(expected, new, null)
+    }
+
+    actual fun setOrThrow(expected: T, new: T, debugInfo: (() -> String)?) {
         compareAndSet(expected, new)
     }
 

--- a/foundation/src/jvmMain/kotlin/com/mirego/trikot/foundation/concurrent/AtomicReference.kt
+++ b/foundation/src/jvmMain/kotlin/com/mirego/trikot/foundation/concurrent/AtomicReference.kt
@@ -10,8 +10,13 @@ actual class AtomicReference<T> actual constructor(value: T) {
     }
 
     actual fun setOrThrow(expected: T, new: T) {
+        setOrThrow(expected, new, null)
+    }
+
+    actual fun setOrThrow(expected: T, new: T, debugInfo: (() -> String)?) {
         if (!internalRef.compareAndSet(expected, new)) {
-            throw ConcurrentModificationException("Unable to set the new value to AtomicReference. Possible Race Condition. Expected value $expected was ${internalRef.get()}")
+            val debugInformationString = debugInfo?.let { "\n${it()}" }
+            throw ConcurrentModificationException("Unable to set $new to AtomicReference. Possible Race Condition. Expected value $expected was ${internalRef.get()}. $debugInformationString")
         }
     }
 

--- a/foundation/src/nativeMain/kotlin/com/mirego/trikot/foundation/concurrent/AtomicReference.kt
+++ b/foundation/src/nativeMain/kotlin/com/mirego/trikot/foundation/concurrent/AtomicReference.kt
@@ -24,8 +24,13 @@ actual class AtomicReference<T> actual constructor(value: T) {
     }
 
     actual fun setOrThrow(expected: T, new: T) {
+        setOrThrow(expected, new, null)
+    }
+
+    actual fun setOrThrow(expected: T, new: T, debugInfo: (() -> String)?) {
         if (!compareAndSet(expected, new)) {
-            throw ConcurrentModificationException("($this) Unable to set $new to AtomicReference. Possible Race Condition. Expected value $expected was $value (Unfrozen: $unfrozenValue). (Internal: ${nativeAtomicReference.value}) Is class frozen: $isFrozen")
+            val debugInformationString = debugInfo?.let { "\n${it()}" }
+            throw ConcurrentModificationException("($this) Unable to set $new to AtomicReference. Possible Race Condition. Expected value $expected was $value (Unfrozen: $unfrozenValue). (Internal: ${nativeAtomicReference.value}) Is class frozen: $isFrozen. $debugInformationString")
         }
     }
 


### PR DESCRIPTION
`Trikot.Streams` uses a lot `setOrThrow` method to make sure there is no race condition. However, when that happens, its hard to know who originated the call.

To allow easier debugging, we add a block parameter that can provide additional information to the throw message.