### PR TITLE
Remove SimpleDateFormat to use thread safe DateTimeFormater instead

### DIFF
--- a/foundation/src/jvmMain/kotlin/com/mirego/trikot/foundation/date/Date.kt
+++ b/foundation/src/jvmMain/kotlin/com/mirego/trikot/foundation/date/Date.kt
@@ -4,13 +4,13 @@ import org.threeten.bp.Instant
 import org.threeten.bp.OffsetDateTime.from
 import org.threeten.bp.ZoneOffset
 import org.threeten.bp.format.DateTimeFormatter
-import java.util.*
+import java.util.Locale
 import kotlin.time.Duration
 import kotlin.time.ExperimentalTime
 
 private val dateFormat =
     DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss'Z'", Locale.US)
-        .withZone( ZoneOffset.UTC )
+        .withZone(ZoneOffset.UTC)
 
 @ExperimentalTime
 actual class Date(val instant: Instant) {


### PR DESCRIPTION
Replace SimpleDateFormater (which is not thread safe) with DateTimeFormater instead. 
https://www.callicoder.com/java-simpledateformat-thread-safety-issues/