### PR TITLE
Add DataConverter helper to convert byte array to nsdata

### DIFF
--- a/foundation/src/nativeMain/kotlin/com/mirego/trikot/foundation/helpers/ByteArrayNativeUtils.kt
+++ b/foundation/src/nativeMain/kotlin/com/mirego/trikot/foundation/helpers/ByteArrayNativeUtils.kt
@@ -1,0 +1,30 @@
+package com.mirego.trikot.foundation.helpers
+
+import kotlinx.cinterop.addressOf
+import kotlinx.cinterop.allocArrayOf
+import kotlinx.cinterop.memScoped
+import kotlinx.cinterop.usePinned
+import platform.Foundation.NSData
+import platform.Foundation.create
+import platform.posix.memcpy
+
+object ByteArrayNativeUtils {
+    @ExperimentalUnsignedTypes
+    fun convert(data: NSData): ByteArray {
+        val memScopedData = memScoped { data }
+        val byteArray = ByteArray(memScopedData.length.toInt()).apply {
+            usePinned {
+                memcpy(it.addressOf(0), memScopedData.bytes, memScopedData.length)
+            }
+        }
+        return byteArray
+    }
+
+    @ExperimentalUnsignedTypes
+    fun convert(byteArray: ByteArray): NSData {
+        return memScoped {
+            NSData.create(bytes = allocArrayOf(byteArray),
+                length = byteArray.size.toULong())
+        }
+    }
+}


### PR DESCRIPTION
We add a simple helper to convert NSData to ByteArray and ByteArray to NSData. This is useful when we want to pass byte arrays to our common platform.