### PR TITLE
Fix date compareTo operator and add equals check

### DIFF
--- a/foundation/src/commonMain/kotlin/com/mirego/trikot/foundation/date/Date.kt
+++ b/foundation/src/commonMain/kotlin/com/mirego/trikot/foundation/date/Date.kt
@@ -13,6 +13,8 @@ expect class Date {
 
     operator fun compareTo(other: Date): Int
 
+    override fun equals(other: Any?): Boolean
+
     companion object DateFactory {
         val now: Date
         fun fromISO8601(isoDate: String): Date

--- a/foundation/src/jsMain/kotlin/com/mirego/trikot/foundation/date/Date.kt
+++ b/foundation/src/jsMain/kotlin/com/mirego/trikot/foundation/date/Date.kt
@@ -16,7 +16,21 @@ actual class Date(val date: kotlin.js.Date) {
     }
 
     actual operator fun compareTo(other: Date): Int {
-        return (epoch - other.epoch).toInt()
+        val difference = epoch - other.epoch
+
+        if (difference == 0L) {
+            return 0
+        }
+
+        return if (difference > 0L) 1 else -1
+    }
+
+    actual override fun equals(other: Any?): Boolean {
+        if (other is Date) {
+            return epoch == other.epoch
+        }
+
+        return false
     }
 
     actual companion object DateFactory {

--- a/foundation/src/jvmMain/kotlin/com/mirego/trikot/foundation/date/Date.kt
+++ b/foundation/src/jvmMain/kotlin/com/mirego/trikot/foundation/date/Date.kt
@@ -24,7 +24,21 @@ actual class Date(val instant: Instant) {
     }
 
     actual operator fun compareTo(other: Date): Int {
-        return (epoch - other.epoch).toInt()
+        val difference = epoch - other.epoch
+
+        if (difference == 0L) {
+            return 0
+        }
+
+        return if (difference > 0L) 1 else -1
+    }
+
+    actual override fun equals(other: Any?): Boolean {
+        if (other is Date) {
+            return epoch == other.epoch
+        }
+
+        return false
     }
 
     actual fun toISO8601(): String {

--- a/foundation/src/nativeMain/kotlin/com/mirego/trikot/foundation/date/Date.kt
+++ b/foundation/src/nativeMain/kotlin/com/mirego/trikot/foundation/date/Date.kt
@@ -35,6 +35,20 @@ actual class Date(val nsDate: NSDate) {
     }
 
     actual operator fun compareTo(other: Date): Int {
-        return (epoch - other.epoch).toInt()
+        val difference = epoch - other.epoch
+
+        if (difference == 0L) {
+            return 0
+        }
+
+        return if (difference > 0L) 1 else -1
+    }
+
+    actual override fun equals(other: Any?): Boolean {
+        if (other is Date) {
+            return epoch == other.epoch
+        }
+
+        return false
     }
 }


### PR DESCRIPTION
If we were comparing dates that were more than 20 days apart, we had numbers bigger that the max int and it returned false even if the date was after.

Now, we only return -1, 0, 1 depending on the scenario.

I also added an equals overload since we were not able to do equality check correctly on date.