### PR TITLE
Fix jvm platform timer

### DIFF
--- a/foundation/src/jvmMain/kotlin/com/mirego/trikot/foundation/timers/PlatformTimer.kt
+++ b/foundation/src/jvmMain/kotlin/com/mirego/trikot/foundation/timers/PlatformTimer.kt
@@ -10,7 +10,7 @@ import java.util.Timer
 actual class PlatformTimer actual constructor(delay: Duration, repeat: Boolean, block: () -> Unit) :
     com.mirego.trikot.foundation.timers.Timer {
     private val timer = if (repeat)
-        Timer(true).scheduleAtFixedRate(delay.toLongMilliseconds(), Long.MAX_VALUE) { block() }
+        Timer(true).scheduleAtFixedRate(delay.toLongMilliseconds(), delay.toLongMilliseconds()) { block() }
     else
         Timer(true).schedule(delay.toLongMilliseconds()) { block() }
 


### PR DESCRIPTION
## Description
Jvm repeatable platform timer was using the "period" parameter of scheduleAtFixedRate as the "life time" of the timer instead of the time between successive task executions. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)