### PR TITLE
Remove memscoped byte allocations in ByteArrayNativeUtils

### DIFF
--- a/foundation/src/nativeMain32/kotlin/com/mirego/trikot/foundation/helpers/ByteArrayNativeUtils.kt
+++ b/foundation/src/nativeMain32/kotlin/com/mirego/trikot/foundation/helpers/ByteArrayNativeUtils.kt
@@ -11,19 +11,17 @@ import platform.posix.memcpy
 object ByteArrayNativeUtils {
     @ExperimentalUnsignedTypes
     fun convert(data: NSData): ByteArray {
-        val memScopedData = memScoped { data }
-        val byteArray = ByteArray(memScopedData.length.toInt()).apply {
+        val byteArray = ByteArray(data.length.toInt()).apply {
             usePinned {
-                memcpy(it.addressOf(0), memScopedData.bytes, memScopedData.length)
+                memcpy(it.addressOf(0), data.bytes, data.length)
             }
         }
         return byteArray
     }
-
     @ExperimentalUnsignedTypes
     fun convert(byteArray: ByteArray): NSData {
-        return memScoped {
-            NSData.create(bytes = allocArrayOf(byteArray),
+        return byteArray.usePinned {
+            NSData.create(bytes = it.addressOf(0),
                 length = byteArray.size.toUInt())
         }
     }

--- a/foundation/src/nativeMain64/kotlin/com/mirego/trikot/foundation/helpers/ByteArrayNativeUtils.kt
+++ b/foundation/src/nativeMain64/kotlin/com/mirego/trikot/foundation/helpers/ByteArrayNativeUtils.kt
@@ -11,19 +11,17 @@ import platform.posix.memcpy
 object ByteArrayNativeUtils {
     @ExperimentalUnsignedTypes
     fun convert(data: NSData): ByteArray {
-        val memScopedData = memScoped { data }
-        val byteArray = ByteArray(memScopedData.length.toInt()).apply {
+        val byteArray = ByteArray(data.length.toInt()).apply {
             usePinned {
-                memcpy(it.addressOf(0), memScopedData.bytes, memScopedData.length)
+                memcpy(it.addressOf(0), data.bytes, data.length)
             }
         }
         return byteArray
     }
-
     @ExperimentalUnsignedTypes
     fun convert(byteArray: ByteArray): NSData {
-        return memScoped {
-            NSData.create(bytes = allocArrayOf(byteArray),
+        return byteArray.usePinned {
+            NSData.create(bytes = it.addressOf(0),
                 length = byteArray.size.toULong())
         }
     }


### PR DESCRIPTION
After exchanging with Nikolay Igotti, Memscoped calls were not necessary as we do not allocate memory.

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
