### PR TITLE
Fix atomic list reference early exit

### DIFF
--- a/foundation/src/commonMain/kotlin/com/mirego/trikot/foundation/concurrent/AtomicListReference.kt
+++ b/foundation/src/commonMain/kotlin/com/mirego/trikot/foundation/concurrent/AtomicListReference.kt
@@ -22,17 +22,12 @@ class AtomicListReference<T> {
     }
 
     private fun mutateWhenReady(block: (value: List<T>) -> List<T>): List<T> {
-        var oldList: List<T>
-        var newList: List<T>
-        do {
-            oldList = value
-            newList = block(oldList)
-            if (oldList == newList) {
-                return oldList
-            }
-            freeze(newList)
-        } while (!internalReference.compareAndSet(oldList, newList))
-
-        return newList
+        val oldList = value
+        val newList = block(oldList)
+        return if (internalReference.compareAndSet(oldList, newList)) {
+            newList
+        } else {
+            mutateWhenReady(block)
+        }
     }
 }


### PR DESCRIPTION
## Motivation and Context
1 - returning at `if (oldList == newList)` may not be accurate as the "oldList" may have change on another thread. All code must use `compareAndSet` validation.

2 - Instead of looping and always reassigning values in oldList, we use the recursivity pattern

## How Has This Been Tested?
In trikot.streams tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
