### PR TITLE
Move freezing responsibility to the DispatchQueue implememtation

### DIFF
--- a/foundation/src/commonMain/kotlin/com/mirego/trikot/foundation/concurrent/dispatchQueue/DispatchQueue.kt
+++ b/foundation/src/commonMain/kotlin/com/mirego/trikot/foundation/concurrent/dispatchQueue/DispatchQueue.kt
@@ -1,7 +1,5 @@
 package com.mirego.trikot.foundation.concurrent.dispatchQueue
 
-import com.mirego.trikot.foundation.concurrent.freeze
-
 typealias DispatchBlock = () -> Unit
 
 interface DispatchQueue {
@@ -14,6 +12,5 @@ interface QueueDispatcher {
 }
 
 fun QueueDispatcher.dispatch(block: DispatchBlock) {
-    freeze(block)
     dispatchQueue.dispatch(block)
 }


### PR DESCRIPTION
## Description
As we may use the `QueueDispatcher.dispatch` extension function in a synchronous environment, we delegate the responsibility to the queue to freeze the block if necessary. The default native DispatchQueue `iOSDispatchQueue` already freeze the block before switching thread.

## Motivation and Context
When using SynchronousSerialQueue, we always unnecessarily freeze objects. Now, objects will be frozen only when necessary.

## How Has This Been Tested?
In all Mirego's application that are using queues. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)
