### PR TITLE
Allow date creation from epoch timestamp

### DIFF
--- a/foundation/src/commonMain/kotlin/com/mirego/trikot/foundation/date/Date.kt
+++ b/foundation/src/commonMain/kotlin/com/mirego/trikot/foundation/date/Date.kt
@@ -18,5 +18,6 @@ expect class Date {
     companion object DateFactory {
         val now: Date
         fun fromISO8601(isoDate: String): Date
+        fun fromEpoch(epoch: Long): Date
     }
 }

--- a/foundation/src/commonMain/kotlin/com/mirego/trikot/foundation/date/Date.kt
+++ b/foundation/src/commonMain/kotlin/com/mirego/trikot/foundation/date/Date.kt
@@ -18,6 +18,6 @@ expect class Date {
     companion object DateFactory {
         val now: Date
         fun fromISO8601(isoDate: String): Date
-        fun fromEpoch(epoch: Long): Date
+        fun fromEpochMillis(epoch: Long): Date
     }
 }

--- a/foundation/src/commonTest/kotlin/com/mirego/trikot/foundation/date/DateHelperTest.kt
+++ b/foundation/src/commonTest/kotlin/com/mirego/trikot/foundation/date/DateHelperTest.kt
@@ -2,6 +2,7 @@ package com.mirego.trikot.foundation.date
 
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 import kotlin.time.ExperimentalTime
 import kotlin.time.minutes
 
@@ -21,5 +22,10 @@ class DateHelperTest {
         assertEquals(0, DateHelper.compare(date, date))
         assertEquals(-1, DateHelper.compare(date, Date.now.plus(2.minutes)))
         assertEquals(1, DateHelper.compare(date, Date.now.plus((-10).minutes)))
+    }
+
+    @Test
+    fun testDateFactory() {
+        assertTrue(DateHelper.equals(Date.fromISO8601("2020-01-01T00:00:00Z"), Date.fromEpochMillis(1577836800000)))
     }
 }

--- a/foundation/src/jsMain/kotlin/com/mirego/trikot/foundation/date/Date.kt
+++ b/foundation/src/jsMain/kotlin/com/mirego/trikot/foundation/date/Date.kt
@@ -38,7 +38,7 @@ actual class Date(val date: kotlin.js.Date) {
             )
         }
 
-        actual fun fromEpoch(epoch: Long): Date {
+        actual fun fromEpochMillis(epoch: Long): Date {
             return Date(kotlin.js.Date(epoch))
         }
     }

--- a/foundation/src/jsMain/kotlin/com/mirego/trikot/foundation/date/Date.kt
+++ b/foundation/src/jsMain/kotlin/com/mirego/trikot/foundation/date/Date.kt
@@ -37,5 +37,9 @@ actual class Date(val date: kotlin.js.Date) {
                 )
             )
         }
+
+        actual fun fromEpoch(epoch: Long): Date {
+            return Date(kotlin.js.Date(epoch))
+        }
     }
 }

--- a/foundation/src/jvmMain/kotlin/com/mirego/trikot/foundation/date/Date.kt
+++ b/foundation/src/jvmMain/kotlin/com/mirego/trikot/foundation/date/Date.kt
@@ -36,13 +36,12 @@ actual class Date(val instant: Instant) {
     }
 
     actual companion object DateFactory {
+        actual val now: Date get() = Date(Instant.now())
 
         private val dateTimeFormatter = DateTimeFormatter.ISO_OFFSET_DATE_TIME
 
-        actual fun fromISO8601(isoDate: String): Date {
-            return Date(dateTimeFormatter.parse(isoDate) { from(it) }.toInstant())
-        }
+        actual fun fromISO8601(isoDate: String): Date = Date(dateTimeFormatter.parse(isoDate) { from(it) }.toInstant())
 
-        actual val now: Date get() = Date(Instant.now())
+        actual fun fromEpoch(epoch: Long): Date = Date(Instant.ofEpochMilli(epoch))
     }
 }

--- a/foundation/src/jvmMain/kotlin/com/mirego/trikot/foundation/date/Date.kt
+++ b/foundation/src/jvmMain/kotlin/com/mirego/trikot/foundation/date/Date.kt
@@ -42,6 +42,6 @@ actual class Date(val instant: Instant) {
 
         actual fun fromISO8601(isoDate: String): Date = Date(dateTimeFormatter.parse(isoDate) { from(it) }.toInstant())
 
-        actual fun fromEpoch(epoch: Long): Date = Date(Instant.ofEpochMilli(epoch))
+        actual fun fromEpochMillis(epoch: Long): Date = Date(Instant.ofEpochMilli(epoch))
     }
 }

--- a/foundation/src/nativeMain/kotlin/com/mirego/trikot/foundation/date/Date.kt
+++ b/foundation/src/nativeMain/kotlin/com/mirego/trikot/foundation/date/Date.kt
@@ -20,6 +20,8 @@ actual class Date(val nsDate: NSDate) {
     }
 
     actual companion object DateFactory {
+        private const val epochReferenceDateDelta: Double = 978307200.0
+
         actual val now: Date
             get() {
                 return Date(NSDate())
@@ -31,6 +33,10 @@ actual class Date(val nsDate: NSDate) {
                     isoDate
                 ) ?: NSDate()
             )
+        }
+
+        actual fun fromEpoch(epoch: Long): Date {
+            return Date(NSDate(timeIntervalSinceReferenceDate = (epoch.toDouble() / 1000.0) + epochReferenceDateDelta))
         }
     }
 

--- a/foundation/src/nativeMain/kotlin/com/mirego/trikot/foundation/date/Date.kt
+++ b/foundation/src/nativeMain/kotlin/com/mirego/trikot/foundation/date/Date.kt
@@ -35,7 +35,7 @@ actual class Date(val nsDate: NSDate) {
             )
         }
 
-        actual fun fromEpoch(epoch: Long): Date {
+        actual fun fromEpochMillis(epoch: Long): Date {
             return Date(NSDate(timeIntervalSinceReferenceDate = (epoch.toDouble() / 1000.0) + epochReferenceDateDelta))
         }
     }


### PR DESCRIPTION
Add the ability to create a date from an epoch timestamp.

## Description
- Adds `DateFactory.fromEpochMillis()` factory method

## Motivation and Context
Allows date conversion from epoch based APIs like `File.lastModified()`.

## Note
For some reason, the constructor `NSDate(timeIntervalSince1970:)` is not exposed in Kotlin native, we achieve the same result by adding the delta between 1970 and the reference date (00:00:00 UTC on 1 January 2001).

## How Has This Been Tested?
Test by comparing a date created from epoch to a date created with a ISO8601 string.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
