### PR TITLE
Weak atomic reference property delegate

### DIFF
--- a/foundation/src/commonMain/kotlin/com/mirego/trikot/foundation/ref/WeakProperty.kt
+++ b/foundation/src/commonMain/kotlin/com/mirego/trikot/foundation/ref/WeakProperty.kt
@@ -19,16 +19,16 @@ fun <T : Any> weakAtomicReference() =
  * Weak atomic reference to a variable of type [T].
  */
 class WeakProperty<T : Any> : ReadWriteProperty<Any?, T?> {
-    private val internalNavigationDelegateRef = AtomicReference<WeakReference<T>?>(null)
-    private val delegate: T? get() = internalNavigationDelegateRef.value?.get()
+    private val internalReference = AtomicReference<WeakReference<T>?>(null)
+    private val delegate: T? get() = internalReference.value?.get()
 
     override fun getValue(thisRef: Any?, property: KProperty<*>): T? {
         return delegate
     }
 
     override fun setValue(thisRef: Any?, property: KProperty<*>, value: T?) {
-        internalNavigationDelegateRef.setOrThrow(
-            internalNavigationDelegateRef.value,
+        internalReference.setOrThrow(
+            internalReference.value,
             value?.let { WeakReference(it) }
         )
     }

--- a/foundation/src/commonMain/kotlin/com/mirego/trikot/foundation/ref/WeakProperty.kt
+++ b/foundation/src/commonMain/kotlin/com/mirego/trikot/foundation/ref/WeakProperty.kt
@@ -1,0 +1,36 @@
+package com.mirego.trikot.foundation.ref
+
+import com.mirego.trikot.foundation.concurrent.AtomicReference
+import kotlin.properties.ReadWriteProperty
+import kotlin.reflect.KProperty
+
+/**
+ * Creates weak atomic reference property delegate.
+ * It can only be used in initialize of read-only property, like this:
+ *
+ * ```
+ * val weakType : Type? by weakReference()
+ * ```
+ */
+fun <T : Any> weakAtomicReference() =
+    WeakProperty<T>()
+
+
+/**
+ * Weak atomic reference to a variable of type [T].
+ */
+class WeakProperty<T : Any> : ReadWriteProperty<Any?, T?> {
+    private val internalNavigationDelegateRef = AtomicReference<WeakReference<T>?>(null)
+    private val delegate: T? get() = internalNavigationDelegateRef.value?.get()
+
+    override fun getValue(thisRef: Any?, property: KProperty<*>): T? {
+        return delegate
+    }
+
+    override fun setValue(thisRef: Any?, property: KProperty<*>, value: T?) {
+        internalNavigationDelegateRef.setOrThrow(
+            internalNavigationDelegateRef.value,
+            value?.let { WeakReference(it) }
+        )
+    }
+}

--- a/foundation/src/commonMain/kotlin/com/mirego/trikot/foundation/ref/WeakProperty.kt
+++ b/foundation/src/commonMain/kotlin/com/mirego/trikot/foundation/ref/WeakProperty.kt
@@ -6,7 +6,7 @@ import kotlin.reflect.KProperty
 
 /**
  * Creates weak atomic reference property delegate.
- * It can only be used in initialize of read-only property, like this:
+ * It can only be used in initialize of read-write optional property, like this:
  *
  * ```
  * val weakType : Type? by weakReference()

--- a/foundation/src/commonMain/kotlin/com/mirego/trikot/foundation/ref/WeakProperty.kt
+++ b/foundation/src/commonMain/kotlin/com/mirego/trikot/foundation/ref/WeakProperty.kt
@@ -15,7 +15,6 @@ import kotlin.reflect.KProperty
 fun <T : Any> weakAtomicReference() =
     WeakProperty<T>()
 
-
 /**
  * Weak atomic reference to a variable of type [T].
  */


### PR DESCRIPTION
## Description
Introduce weak atomic reference property delegate.

## Motivation and Context
We wanted to use a weak atomic reference for our navigation delegate, which can be used across multiple workers.

The previous solution with the navigation delegate being wrapped in a `WeakDelegate` obliged us to override each method manually, which was boilerplate heavy.

## How Has This Been Tested?
It was tested both on android and iOS.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
