### PR TITLE
Fix iOS date conversion

### DIFF
--- a/trikotFoundation/src/nativeMain/kotlin/com/mirego/trikot/foundation/date/Date.kt
+++ b/trikotFoundation/src/nativeMain/kotlin/com/mirego/trikot/foundation/date/Date.kt
@@ -36,7 +36,7 @@ actual class Date(val nsDate: NSDate) {
         }
 
         actual fun fromEpochMillis(epoch: Long): Date {
-            return Date(NSDate(timeIntervalSinceReferenceDate = (epoch.toDouble() / 1000.0) + epochReferenceDateDelta))
+            return Date(NSDate(timeIntervalSinceReferenceDate = (epoch.toDouble() / 1000.0) - epochReferenceDateDelta))
         }
     }
 


### PR DESCRIPTION
We need to remove the delta between 1970 and 2001 since we are using `timeIntervalSinceReferenceDate`.

## How Has This Been Tested?

`Date.fromEpochMillis(epoch).epoch` now return the same epoch given to `fromEpochMillis`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
