### PR TITLE
AtomicReference property delegates

### DIFF
--- a/trikotFoundation/build.gradle
+++ b/trikotFoundation/build.gradle
@@ -41,6 +41,7 @@ kotlin {
         fromPreset(presets.tvosArm64, 'tvosArm64')
         fromPreset(presets.tvosX64, 'tvosX64')
     }
+
     sourceSets {
         all {
             languageSettings {
@@ -109,8 +110,16 @@ kotlin {
             dependsOn(nativeMain)
         }
 
+        nativeTest {
+            dependsOn commonTest
+        }
+
         configure([iosX64Main, iosArm64Main, tvosArm64Main, tvosX64Main]) {
             dependsOn nativeMain64
+        }
+
+        configure([iosX64Test, iosArm64Test, tvosArm64Test, tvosX64Test, iosArm32Test]) {
+            dependsOn nativeTest
         }
 
         iosArm32Main {

--- a/trikotFoundation/src/commonMain/kotlin/com/mirego/trikot/foundation/concurrent/AtomicProperty.kt
+++ b/trikotFoundation/src/commonMain/kotlin/com/mirego/trikot/foundation/concurrent/AtomicProperty.kt
@@ -1,0 +1,31 @@
+package com.mirego.trikot.foundation.concurrent
+
+import kotlin.properties.ReadWriteProperty
+import kotlin.reflect.KProperty
+
+fun <T> atomic(initialValue: T) = AtomicProperty(initialValue)
+fun <T : Any> atomicNullable(initialValue: T? = null) = AtomicNullableProperty(initialValue)
+
+class AtomicProperty<T>(initialValue: T) : ReadWriteProperty<Any?, T> {
+    private val internalReference = AtomicReference(initialValue)
+
+    override fun getValue(thisRef: Any?, property: KProperty<*>): T {
+        return internalReference.value
+    }
+
+    override fun setValue(thisRef: Any?, property: KProperty<*>, value: T) {
+        internalReference.setOrThrow(value)
+    }
+}
+
+class AtomicNullableProperty<T : Any>(initialValue: T? = null) : ReadWriteProperty<Any?, T?> {
+    private val internalReference = AtomicReference(initialValue)
+
+    override fun getValue(thisRef: Any?, property: KProperty<*>): T? {
+        return internalReference.value
+    }
+
+    override fun setValue(thisRef: Any?, property: KProperty<*>, value: T?) {
+        internalReference.setOrThrow(value)
+    }
+}

--- a/trikotFoundation/src/commonMain/kotlin/com/mirego/trikot/foundation/concurrent/AtomicReference.kt
+++ b/trikotFoundation/src/commonMain/kotlin/com/mirego/trikot/foundation/concurrent/AtomicReference.kt
@@ -11,3 +11,7 @@ expect class AtomicReference<T>(value: T) {
 
     fun compareAndSwap(expected: T, new: T): T
 }
+
+fun <T> AtomicReference<T>.setOrThrow(new: T) {
+    setOrThrow(value, new)
+}

--- a/trikotFoundation/src/commonTest/kotlin/com/mirego/trikot/foundation/concurrent/AtomicPropertyTest.kt
+++ b/trikotFoundation/src/commonTest/kotlin/com/mirego/trikot/foundation/concurrent/AtomicPropertyTest.kt
@@ -1,0 +1,35 @@
+package com.mirego.trikot.foundation.concurrent
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class AtomicPropertyTest {
+
+    private var atomicPropertyNullable: Int? by atomicNullable()
+    private var atomicPropertyNullableWithValue: Int? by atomicNullable(1)
+    private var atomicPropertyNotNull: Int by atomic(2)
+
+    @Test
+    fun testNullableAtomicPropertyNoDefaultValue() {
+        assertNull(atomicPropertyNullable)
+        atomicPropertyNullable = 1
+        assertEquals(atomicPropertyNullable, 1)
+        atomicPropertyNullable = null
+        assertNull(atomicPropertyNullable)
+    }
+
+    @Test
+    fun testNullableAtomicPropertyWithValue() {
+        assertEquals(atomicPropertyNullableWithValue, 1)
+        atomicPropertyNullableWithValue = null
+        assertNull(atomicPropertyNullableWithValue)
+    }
+
+    @Test
+    fun testNotNullAtomicPropertyWithValue() {
+        assertEquals(atomicPropertyNotNull, 2)
+        atomicPropertyNotNull = 3
+        assertEquals(atomicPropertyNotNull, 3)
+    }
+}

--- a/trikotFoundation/src/nativeTest/kotlin/com/mirego/trikot/foundation/concurrent/AtomicPropertyNativeTest.kt
+++ b/trikotFoundation/src/nativeTest/kotlin/com/mirego/trikot/foundation/concurrent/AtomicPropertyNativeTest.kt
@@ -1,0 +1,37 @@
+package com.mirego.trikot.foundation.concurrent
+
+import kotlin.test.Test
+import kotlin.native.concurrent.freeze
+import kotlin.native.concurrent.isFrozen
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class AtomicPropertyNativeTest {
+
+    private var atomicPropertyNullable: Any? by atomicNullable(Any())
+    private var atomicPropertyNullableWithValue: Any by atomic(Any())
+    private var atomicPropertyNullableFrozen: Any? by atomicNullable(Any()).freeze()
+    private var atomicPropertyNullableWithValueFrozen: Any by atomic(Any()).freeze()
+
+    @Test
+    fun testValueIsNeverFrozenByDefault() {
+        assertFalse(atomicPropertyNullable.isFrozen)
+        atomicPropertyNullable = Any()
+        assertFalse(atomicPropertyNullable.isFrozen)
+
+        assertFalse(atomicPropertyNullableWithValue.isFrozen)
+        atomicPropertyNullableWithValue = Any()
+        assertFalse(atomicPropertyNullableWithValue.isFrozen)
+    }
+
+    @Test
+    fun testValueIsFrozenIfDelegateIsFrozen() {
+        assertTrue(atomicPropertyNullableFrozen.isFrozen)
+        atomicPropertyNullableFrozen = Any()
+        assertTrue(atomicPropertyNullableFrozen.isFrozen)
+
+        assertTrue(atomicPropertyNullableWithValueFrozen.isFrozen)
+        atomicPropertyNullableWithValueFrozen = Any()
+        assertTrue(atomicPropertyNullableWithValueFrozen.isFrozen)
+    }
+}


### PR DESCRIPTION
## Description
Introduce property delegates for atomic references.
Added a native test sourceset to test .

### Usage:
```kotlin
var property: Int by atomic(1)
var propertyNullable: Int? by atomicNullable()
```

## Motivation and Context
This helps interacting with atomics in basic use cases a bit more concisely.

## How Has This Been Tested?
Unit tested

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
