### PR TITLE
Fix IOSSerialDispatchQueue

### DIFF
--- a/trikotFoundation/src/iosArm32Main/kotlin/com/mirego/trikot/foundation/concurrent/dispatchQueue/IOSSerialDispatchQueue.kt
+++ b/trikotFoundation/src/iosArm32Main/kotlin/com/mirego/trikot/foundation/concurrent/dispatchQueue/IOSSerialDispatchQueue.kt
@@ -1,14 +1,15 @@
 package com.mirego.trikot.foundation.concurrent.dispatchQueue
 
 import com.mirego.trikot.foundation.concurrent.freeze
+import platform.darwin.DISPATCH_QUEUE_SERIAL
 import platform.darwin.dispatch_async
 import platform.darwin.dispatch_queue_create
-import platform.darwin.dispatch_queue_serial_t
+import platform.darwin.dispatch_queue_t
 
 open class IOSSerialDispatchQueue(identifier: String) : DispatchQueue {
     private val serialQueue = dispatch_queue_create(
         "com.mirego.trikot.foundation.serial_dispatch_queue.$identifier",
-        dispatch_queue_serial_t()
+        DISPATCH_QUEUE_SERIAL as dispatch_queue_t
     )
 
     override fun isSerial() = true

--- a/trikotFoundation/src/iosMain/kotlin/com/mirego/trikot/foundation/concurrent/dispatchQueue/IOSSerialDispatchQueue.kt
+++ b/trikotFoundation/src/iosMain/kotlin/com/mirego/trikot/foundation/concurrent/dispatchQueue/IOSSerialDispatchQueue.kt
@@ -1,14 +1,15 @@
 package com.mirego.trikot.foundation.concurrent.dispatchQueue
 
 import com.mirego.trikot.foundation.concurrent.freeze
+import platform.darwin.DISPATCH_QUEUE_SERIAL
 import platform.darwin.dispatch_async
 import platform.darwin.dispatch_queue_create
-import platform.darwin.dispatch_queue_serial_t
+import platform.darwin.dispatch_queue_t
 
 open class IOSSerialDispatchQueue(identifier: String) : DispatchQueue {
     private val serialQueue = dispatch_queue_create(
         "com.mirego.trikot.foundation.serial_dispatch_queue.$identifier",
-        dispatch_queue_serial_t()
+        DISPATCH_QUEUE_SERIAL as dispatch_queue_t
     )
 
     override fun isSerial() = true


### PR DESCRIPTION
## Description
 dispatch_queue_serial_t() seems invalid for iOS 4.3+. We replace the constructor argument with NULL.

## Motivation and Context
It was not working as expected.

## How Has This Been Tested?
In a separate test project

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
