### PR TITLE
Add String.normalize() extension to remove diacritics from string

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Trikot.foundation
-Kotlin Multiplatform implementation of threads, timers, atomic references and iso8601 dates.
+Kotlin Multiplatform implementation of threads, timers, atomic references, string utilities and iso8601 dates.
 
 ## AtomicReference and AtomicListReference
 AtomicReference implementation on all platform 
@@ -20,6 +20,14 @@ Single and repeatable multiplatform timer implementations
  val doOnceTimer = TimerFactory.single(12.seconds) { doSomething() }
  val repeatTimer = TimerFactory.repeatable(12.seconds) { doSomething() }
  repeatTimer.cancel() // stop the timer
+```
+
+## Strings
+Multiplatform string extensions for formating, normalizing
+
+```kotlin
+val string = "Où sont les bûches de Noël durant l'été?".normalize()
+string == "Ou sont les buches de Noel durant l'ete?" // true
 ```
 
 ## Dates (Basic from and to ISO8601)

--- a/trikotFoundation/src/commonMain/kotlin/com/mirego/trikot/foundation/strings/NativeStringExtensions.kt
+++ b/trikotFoundation/src/commonMain/kotlin/com/mirego/trikot/foundation/strings/NativeStringExtensions.kt
@@ -1,0 +1,3 @@
+package com.mirego.trikot.foundation.strings
+
+expect fun String.normalize(): String

--- a/trikotFoundation/src/commonTest/kotlin/com/mirego/trikot/foundation/strings/NativeStringExtensionsTest.kt
+++ b/trikotFoundation/src/commonTest/kotlin/com/mirego/trikot/foundation/strings/NativeStringExtensionsTest.kt
@@ -7,7 +7,7 @@ class NativeStringExtensionsTest {
     @Test
     fun testNormalize() {
         val cue = "\u00C7\u00FA\u00EA"
-        assertEquals("Cue", cue.normalize(), "Failed to strip accents from $cue")
+        assertEquals("Cue", cue.normalize(), "Failed to strip diacritics from $cue")
 
         val lots = "\u00C0\u00C1\u00C2\u00C3\u00C4\u00C5\u00C7\u00C8\u00C9" +
                 "\u00CA\u00CB\u00CC\u00CD\u00CE\u00CF\u00D1\u00D2\u00D3" +
@@ -15,7 +15,7 @@ class NativeStringExtensionsTest {
         assertEquals(
             "AAAAAACEEEEIIIINOOOOOUUUUY",
             lots.normalize(),
-            "Failed to strip accents from $lots"
+            "Failed to strip diacritics from $lots"
         )
         assertEquals("", "".normalize(), "Failed empty String")
         assertEquals("control", "control".normalize(), "Failed to handle non-accented text")

--- a/trikotFoundation/src/commonTest/kotlin/com/mirego/trikot/foundation/strings/NativeStringExtensionsTest.kt
+++ b/trikotFoundation/src/commonTest/kotlin/com/mirego/trikot/foundation/strings/NativeStringExtensionsTest.kt
@@ -1,0 +1,24 @@
+package com.mirego.trikot.foundation.strings
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class NativeStringExtensionsTest {
+    @Test
+    fun testNormalize() {
+        val cue = "\u00C7\u00FA\u00EA"
+        assertEquals("Cue", cue.normalize(), "Failed to strip accents from $cue")
+
+        val lots = "\u00C0\u00C1\u00C2\u00C3\u00C4\u00C5\u00C7\u00C8\u00C9" +
+                "\u00CA\u00CB\u00CC\u00CD\u00CE\u00CF\u00D1\u00D2\u00D3" +
+                "\u00D4\u00D5\u00D6\u00D9\u00DA\u00DB\u00DC\u00DD"
+        assertEquals(
+            "AAAAAACEEEEIIIINOOOOOUUUUY",
+            lots.normalize(),
+            "Failed to strip accents from $lots"
+        )
+        assertEquals("", "".normalize(), "Failed empty String")
+        assertEquals("control", "control".normalize(), "Failed to handle non-accented text")
+        assertEquals("eclair", "\u00E9clair".normalize(), "Failed to handle easy example")
+    }
+}

--- a/trikotFoundation/src/iosArm32Main/kotlin/com/mirego/trikot/foundation/strings/NativeStringExtensions.kt
+++ b/trikotFoundation/src/iosArm32Main/kotlin/com/mirego/trikot/foundation/strings/NativeStringExtensions.kt
@@ -1,0 +1,10 @@
+package com.mirego.trikot.foundation.strings
+
+import platform.Foundation.NSDiacriticInsensitiveSearch
+import platform.Foundation.NSString
+import platform.Foundation.create
+import platform.Foundation.stringByFoldingWithOptions
+
+actual fun String.normalize(): String =
+    NSString.create(string = this)
+        .stringByFoldingWithOptions(options = NSDiacriticInsensitiveSearch, locale = null)

--- a/trikotFoundation/src/iosMain/kotlin/com/mirego/trikot/foundation/strings/NativeStringExtensions.kt
+++ b/trikotFoundation/src/iosMain/kotlin/com/mirego/trikot/foundation/strings/NativeStringExtensions.kt
@@ -1,0 +1,10 @@
+package com.mirego.trikot.foundation.strings
+
+import platform.Foundation.NSDiacriticInsensitiveSearch
+import platform.Foundation.NSString
+import platform.Foundation.create
+import platform.Foundation.stringByFoldingWithOptions
+
+actual fun String.normalize(): String =
+    NSString.create(string = this)
+        .stringByFoldingWithOptions(options = NSDiacriticInsensitiveSearch, locale = null)

--- a/trikotFoundation/src/jsMain/kotlin/com/mirego/trikot/foundation/strings/NativeStringExtensions.kt
+++ b/trikotFoundation/src/jsMain/kotlin/com/mirego/trikot/foundation/strings/NativeStringExtensions.kt
@@ -1,0 +1,7 @@
+package com.mirego.trikot.foundation.strings
+
+actual fun String.normalize(): String {
+    @Suppress("UNUSED_VARIABLE", "js does not recognize keyword 'this'")
+    val string = this
+    return js("string.normalize(\"NFD\").replace(/[\\u0300-\\u036f]/g, \"\")") as String
+}

--- a/trikotFoundation/src/jvmShared/kotlin/com/mirego/trikot/foundation/strings/NativeStringExtensions.kt
+++ b/trikotFoundation/src/jvmShared/kotlin/com/mirego/trikot/foundation/strings/NativeStringExtensions.kt
@@ -1,0 +1,14 @@
+package com.mirego.trikot.foundation.strings
+
+import java.text.Normalizer
+import java.util.regex.Pattern
+
+actual fun String.normalize(): String =
+    Normalizer.normalize(this, Normalizer.Form.NFD)
+        .replace(NativeStringExtensions.diacriticsRegex, "")
+
+private object NativeStringExtensions {
+    val diacriticsRegex: Regex by lazy {
+        Pattern.compile("\\p{InCombiningDiacriticalMarks}+").toRegex()
+    }
+}


### PR DESCRIPTION
Add multiplatform implementations of a normalize() string extension.

#### Example usage :
```kotlin
val string = "Où sont les bûches de Noël durant l'été?".normalize()
string == "Ou sont les buches de Noel durant l'ete?" // true
```

## Description
Added `jvm`, `js`, `ios` & `tvos` implementations.

## Motivation and Context
Normalizing strings (remove diacritics) is a common use case in our multiplatform projects. Adding it to our Foundation libraries will make this code reusable and force us not to copy-paste when jumping on a new project.

## How Has This Been Tested?
This extension is 100% unit tested and has been tested in the multiple iOS/android apps we've been working on at [Mirego](https://github.com/mirego). 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
