### PR TITLE
Update mirego.release plugin to 2.0 to fix failing build

### DIFF
--- a/trikotFoundation/build.gradle
+++ b/trikotFoundation/build.gradle
@@ -2,7 +2,7 @@ plugins {
     id 'com.android.library'
     id 'kotlin-multiplatform'
     id 'org.jlleitschuh.gradle.ktlint'
-    id 'mirego.release' version '1.16'
+    id 'mirego.release' version '2.0'
     id 'mirego.publish' version '1.0'
 }
 


### PR DESCRIPTION
As mentionned [here](https://github.com/mirego/MiregoGradle/pull/100), using a BuildTask with the latest gradle version (6.*) fails if two projects in the hierarchy have the same name, which is exactly why our current build is failing.

```
> Task :trikotFoundation:release FAILED
Task :trikotFoundation:release in trikotFoundation Finished
:trikotFoundation:release (Thread[Execution worker for ':' Thread 4,5,main]) completed. Took 13.111 secs.

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':mirego-trikot.foundation-plugin_release:trikotFoundation:runBuildTasks'.
> Included build /Users/admin/Jenkins/jenkins-root/workspace/Mirego/trikot.foundation/mirego-trikot.foundation-plugin_release has build path :mirego-trikot.foundation-plugin_release:mirego-trikot.foundation-plugin_release which is the same as included build /Users/admin/Jenkins/jenkins-root/workspace/Mirego/trikot.foundation/mirego-trikot.foundation-plugin_release
```

The [same change](https://github.com/mirego/trikot.streams/commit/ccc53c0350cf5f4e757d633646263a05a51969f8) as already been applied to [trikot.streams](https://github.com/mirego/trikot.streams).
