### PR TITLE
Introduce more basic tuples (from 4 to 10)

### DIFF
--- a/trikotFoundation/src/commonMain/kotlin/com/mirego/trikot/foundation/Tuples.kt
+++ b/trikotFoundation/src/commonMain/kotlin/com/mirego/trikot/foundation/Tuples.kt
@@ -1,0 +1,135 @@
+package com.mirego.trikot.foundation
+
+/**
+ * Represents a group of four (4) values
+ *
+ * There is no meaning attached to values in this class, it can be used for any purpose.
+ * Quadruple exhibits value semantics, i.e. two quadruples are equal if all four components are
+ * equal.
+ *
+ * @param A type of the first value.
+ * @param B type of the second value.
+ * @param C type of the third value.
+ * @param D type of the third value.
+ * @property first First value.
+ * @property second Second value.
+ * @property third Third value.
+ * @property fourth Fourth value.
+ */
+data class Quadruple<out A, out B, out C, out D>(
+    val first: A,
+    val second: B,
+    val third: C,
+    val fourth: D
+) {
+    /**
+     * Returns string representation of the [Triple] including its [first], [second], [third] and
+     * [fourth] values.
+     */
+    override fun toString(): String = "($first, $second, $third, $fourth)"
+}
+
+/**
+ * Represents a group of five (5) values
+ *
+ * There is no meaning attached to values in this class, it can be used for any purpose.
+ * Quintuple exhibits value semantics, i.e. two quintuples are equal if all five components are
+ * equal.
+ *
+ * @param A type of the first value.
+ * @param B type of the second value.
+ * @param C type of the third value.
+ * @param D type of the fourth value.
+ * @param E type of the fifth value.
+ * @property first First value.
+ * @property second Second value.
+ * @property third Third value.
+ * @property fourth Fourth value.
+ * @property fifth Fifth value.
+ */
+data class Quintuple<out A, out B, out C, out D, out E>(
+    val first: A,
+    val second: B,
+    val third: C,
+    val fourth: D,
+    val fifth: E
+) {
+    /**
+     * Returns string representation of the [Triple] including its [first], [second], [third],
+     * [fourth] and [fifth] values.
+     */
+    override fun toString(): String = "($first, $second, $third, $fourth, $fifth)"
+}
+
+/**
+ * Represents a group of six (6) values
+ *
+ * There is no meaning attached to values in this class, it can be used for any purpose.
+ * Sextuple exhibits value semantics, i.e. two sextuples are equal if all six components are
+ * equal.
+ *
+ * @param A type of the first value.
+ * @param B type of the second value.
+ * @param C type of the third value.
+ * @param D type of the fourth value.
+ * @param E type of the fifth value.
+ * @param F type of the sixth value.
+ * @property first First value.
+ * @property second Second value.
+ * @property third Third value.
+ * @property fourth Fourth value.
+ * @property fifth Fifth value.
+ * @property sixth Sixth value.
+ */
+data class Sextuple<out A, out B, out C, out D, out E, out F>(
+    val first: A,
+    val second: B,
+    val third: C,
+    val fourth: D,
+    val fifth: E,
+    val sixth: F
+) {
+    /**
+     * Returns string representation of the [Triple] including its [first], [second], [third],
+     * [fourth], [fifth] and [sixth] values.
+     */
+    override fun toString(): String = "($first, $second, $third, $fourth, $fifth, $sixth)"
+}
+
+/**
+ * Represents a group of seven (7) values
+ *
+ * There is no meaning attached to values in this class, it can be used for any purpose.
+ * Septuple exhibits value semantics, i.e. two septuples are equal if all seven components are
+ * equal.
+ *
+ * @param A type of the first value.
+ * @param B type of the second value.
+ * @param C type of the third value.
+ * @param D type of the fourth value.
+ * @param E type of the fifth value.
+ * @param F type of the sixth value.
+ * @param G type of the seventh value.
+ * @property first First value.
+ * @property second Second value.
+ * @property third Third value.
+ * @property fourth Fourth value.
+ * @property fifth Fifth value.
+ * @property sixth Sixth value.
+ * @property seventh Seventh value.
+ */
+data class Septuple<out A, out B, out C, out D, out E, out F, out G>(
+    val first: A,
+    val second: B,
+    val third: C,
+    val fourth: D,
+    val fifth: E,
+    val sixth: F,
+    val seventh: G
+) {
+    /**
+     * Returns string representation of the [Triple] including its [first], [second], [third],
+     * [fourth], [fifth], [sixth], and [seventh] values.
+     */
+    override fun toString(): String = "($first, $second, $third, $fourth, $fifth, $sixth, $seventh)"
+}

--- a/trikotFoundation/src/commonMain/kotlin/com/mirego/trikot/foundation/Tuples.kt
+++ b/trikotFoundation/src/commonMain/kotlin/com/mirego/trikot/foundation/Tuples.kt
@@ -11,10 +11,10 @@ package com.mirego.trikot.foundation
  * @param B type of the second value.
  * @param C type of the third value.
  * @param D type of the third value.
- * @property first First value.
- * @property second Second value.
- * @property third Third value.
- * @property fourth Fourth value.
+ * @property first First (1st) value.
+ * @property second Second (2nd) value.
+ * @property third Third (3rd) value.
+ * @property fourth Fourth (4th) value.
  */
 data class Quadruple<out A, out B, out C, out D>(
     val first: A,
@@ -23,7 +23,7 @@ data class Quadruple<out A, out B, out C, out D>(
     val fourth: D
 ) {
     /**
-     * Returns string representation of the [Triple] including its [first], [second], [third] and
+     * Returns string representation of the [Quadruple] including its [first], [second], [third] and
      * [fourth] values.
      */
     override fun toString(): String = "($first, $second, $third, $fourth)"
@@ -36,16 +36,11 @@ data class Quadruple<out A, out B, out C, out D>(
  * Quintuple exhibits value semantics, i.e. two quintuples are equal if all five components are
  * equal.
  *
- * @param A type of the first value.
- * @param B type of the second value.
- * @param C type of the third value.
- * @param D type of the fourth value.
- * @param E type of the fifth value.
- * @property first First value.
- * @property second Second value.
- * @property third Third value.
- * @property fourth Fourth value.
- * @property fifth Fifth value.
+ * @property first First (1st) value.
+ * @property second Second (2nd) value.
+ * @property third Third (3rd) value.
+ * @property fourth Fourth (4th) value.
+ * @property fifth Fifth (5th) value.
  */
 data class Quintuple<out A, out B, out C, out D, out E>(
     val first: A,
@@ -55,7 +50,7 @@ data class Quintuple<out A, out B, out C, out D, out E>(
     val fifth: E
 ) {
     /**
-     * Returns string representation of the [Triple] including its [first], [second], [third],
+     * Returns string representation of the [Quintuple] including its [first], [second], [third],
      * [fourth] and [fifth] values.
      */
     override fun toString(): String = "($first, $second, $third, $fourth, $fifth)"
@@ -74,12 +69,12 @@ data class Quintuple<out A, out B, out C, out D, out E>(
  * @param D type of the fourth value.
  * @param E type of the fifth value.
  * @param F type of the sixth value.
- * @property first First value.
- * @property second Second value.
- * @property third Third value.
- * @property fourth Fourth value.
- * @property fifth Fifth value.
- * @property sixth Sixth value.
+ * @property first First (1st) value.
+ * @property second Second (2nd) value.
+ * @property third Third (3rd) value.
+ * @property fourth Fourth (4th) value.
+ * @property fifth Fifth (5th) value.
+ * @property sixth Sixth (6th) value.
  */
 data class Sextuple<out A, out B, out C, out D, out E, out F>(
     val first: A,
@@ -90,7 +85,7 @@ data class Sextuple<out A, out B, out C, out D, out E, out F>(
     val sixth: F
 ) {
     /**
-     * Returns string representation of the [Triple] including its [first], [second], [third],
+     * Returns string representation of the [Sextuple] including its [first], [second], [third],
      * [fourth], [fifth] and [sixth] values.
      */
     override fun toString(): String = "($first, $second, $third, $fourth, $fifth, $sixth)"
@@ -110,13 +105,13 @@ data class Sextuple<out A, out B, out C, out D, out E, out F>(
  * @param E type of the fifth value.
  * @param F type of the sixth value.
  * @param G type of the seventh value.
- * @property first First value.
- * @property second Second value.
- * @property third Third value.
- * @property fourth Fourth value.
- * @property fifth Fifth value.
- * @property sixth Sixth value.
- * @property seventh Seventh value.
+ * @property first First (1st) value.
+ * @property second Second (2nd) value.
+ * @property third Third (3rd) value.
+ * @property fourth Fourth (4th) value.
+ * @property fifth Fifth (5th) value.
+ * @property sixth Sixth (6th) value.
+ * @property seventh Seventh (7th) value.
  */
 data class Septuple<out A, out B, out C, out D, out E, out F, out G>(
     val first: A,
@@ -128,8 +123,143 @@ data class Septuple<out A, out B, out C, out D, out E, out F, out G>(
     val seventh: G
 ) {
     /**
-     * Returns string representation of the [Triple] including its [first], [second], [third],
+     * Returns string representation of the [Septuple] including its [first], [second], [third],
      * [fourth], [fifth], [sixth], and [seventh] values.
      */
     override fun toString(): String = "($first, $second, $third, $fourth, $fifth, $sixth, $seventh)"
+}
+
+/**
+ * Represents a group of eight (8) values
+ *
+ * There is no meaning attached to values in this class, it can be used for any purpose.
+ * Octuple exhibits value semantics, i.e. two octuples are equal if all eight components are
+ * equal.
+ *
+ * @param A type of the first value.
+ * @param B type of the second value.
+ * @param C type of the third value.
+ * @param D type of the fourth value.
+ * @param E type of the fifth value.
+ * @param F type of the sixth value.
+ * @param G type of the seventh value.
+ * @param H type of the eighth value.
+ * @property first First (1st) value.
+ * @property second Second (2nd) value.
+ * @property third Third (3rd) value.
+ * @property fourth Fourth (4th) value.
+ * @property fifth Fifth (5th) value.
+ * @property sixth Sixth (6th) value.
+ * @property seventh Seventh (7th) value.
+ * @property eighth Eighth (8th) value.
+ */
+data class Octuple<out A, out B, out C, out D, out E, out F, out G, out H>(
+    val first: A,
+    val second: B,
+    val third: C,
+    val fourth: D,
+    val fifth: E,
+    val sixth: F,
+    val seventh: G,
+    val eighth: H
+) {
+    /**
+     * Returns string representation of the [Octuple] including its [first], [second], [third],
+     * [fourth], [fifth], [sixth], [seventh] and [eighth] values.
+     */
+    override fun toString(): String = "($first, $second, $third, $fourth, $fifth, " +
+            "$sixth, $seventh, $eighth)"
+}
+
+/**
+ * Represents a group of nine (9) values
+ *
+ * There is no meaning attached to values in this class, it can be used for any purpose.
+ * Nonuple exhibits value semantics, i.e. two nonuples are equal if all nine components are
+ * equal.
+ *
+ * @param A type of the first value.
+ * @param B type of the second value.
+ * @param C type of the third value.
+ * @param D type of the fourth value.
+ * @param E type of the fifth value.
+ * @param F type of the sixth value.
+ * @param G type of the seventh value.
+ * @param H type of the eighth value.
+ * @param I type of the ninth value.
+ * @property first First (1st) value.
+ * @property second Second (2nd) value.
+ * @property third Third (3rd) value.
+ * @property fourth Fourth (4th) value.
+ * @property fifth Fifth (5th) value.
+ * @property sixth Sixth (6th) value.
+ * @property seventh Seventh (7th) value.
+ * @property eighth Eighth (8th) value.
+ * @property ninth Ninth (9th) value.
+ */
+data class Nonuple<out A, out B, out C, out D, out E, out F, out G, out H, out I>(
+    val first: A,
+    val second: B,
+    val third: C,
+    val fourth: D,
+    val fifth: E,
+    val sixth: F,
+    val seventh: G,
+    val eighth: H,
+    val ninth: I
+) {
+    /**
+     * Returns string representation of the [Nonuple] including its [first], [second], [third],
+     * [fourth], [fifth], [sixth], [seventh], [eighth] and [ninth] values.
+     */
+    override fun toString(): String = "($first, $second, $third, $fourth, $fifth, " +
+            "$sixth, $seventh, $eighth, $ninth)"
+}
+
+/**
+ * Represents a group of nine (9) values
+ *
+ * There is no meaning attached to values in this class, it can be used for any purpose.
+ * Decuple exhibits value semantics, i.e. two decuples are equal if all ten components are
+ * equal.
+ *
+ * @param A type of the first value.
+ * @param B type of the second value.
+ * @param C type of the third value.
+ * @param D type of the fourth value.
+ * @param E type of the fifth value.
+ * @param F type of the sixth value.
+ * @param G type of the seventh value.
+ * @param H type of the eighth value.
+ * @param I type of the ninth value.
+ * @param J type of the tenth value.
+ * @property first First (1st) value.
+ * @property second Second (2nd) value.
+ * @property third Third (3rd) value.
+ * @property fourth Fourth (4th) value.
+ * @property fifth Fifth (5th) value.
+ * @property sixth Sixth (6th) value.
+ * @property seventh Seventh (7th) value.
+ * @property eighth Eighth (8th) value.
+ * @property ninth Ninth (9th) value.
+ * @property tenth Tenth (10th) value.
+ */
+data class Decuple<out A, out B, out C, out D, out E, out F, out G, out H, out I, out J>(
+    val first: A,
+    val second: B,
+    val third: C,
+    val fourth: D,
+    val fifth: E,
+    val sixth: F,
+    val seventh: G,
+    val eighth: H,
+    val ninth: I,
+    val tenth: J
+) {
+    /**
+     * Returns string representation of the [Nonuple] including its [first], [second], [third],
+     * [fourth], [fifth], [sixth], [seventh], [eighth], [ninth] and [tenth] values.
+     */
+    override fun toString(): String = "($first, $second, $third, $fourth, $fifth, " +
+            "$sixth, $seventh, $eighth, $ninth, $tenth)"
 }

--- a/trikotFoundation/src/commonTest/kotlin/com/mirego/trikot/foundation/TuplesTest.kt
+++ b/trikotFoundation/src/commonTest/kotlin/com/mirego/trikot/foundation/TuplesTest.kt
@@ -1,0 +1,68 @@
+package com.mirego.trikot.foundation
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class TuplesTest {
+    @Test
+    fun testQuadruple() {
+        val quadruple = Quadruple("1", "2", "3", 4)
+
+        quadruple.let { (a, b, c, d) ->
+            assertEquals("1", a)
+            assertEquals("2", b)
+            assertEquals("3", c)
+            assertEquals(4, d)
+        }
+
+        assertEquals("(1, 2, 3, 4)", quadruple.toString())
+    }
+
+    @Test
+    fun testQuintuple() {
+        val quintuple = Quintuple("1", "2", "3", "4", 5)
+
+        quintuple.let { (a, b, c, d, e) ->
+            assertEquals("1", a)
+            assertEquals("2", b)
+            assertEquals("3", c)
+            assertEquals("4", d)
+            assertEquals(5, e)
+        }
+
+        assertEquals("(1, 2, 3, 4, 5)", quintuple.toString())
+    }
+
+    @Test
+    fun testSextuple() {
+        val sextuple = Sextuple("1", "2", "3", "4", "5", 6)
+
+        sextuple.let { (a, b, c, d, e, f) ->
+            assertEquals("1", a)
+            assertEquals("2", b)
+            assertEquals("3", c)
+            assertEquals("4", d)
+            assertEquals("5", e)
+            assertEquals(6, f)
+        }
+
+        assertEquals("(1, 2, 3, 4, 5, 6)", sextuple.toString())
+    }
+
+    @Test
+    fun testSeptuple() {
+        val septuple = Septuple("1", "2", "3", "4", "5", "6", 7)
+
+        septuple.let { (a, b, c, d, e, f, g) ->
+            assertEquals("1", a)
+            assertEquals("2", b)
+            assertEquals("3", c)
+            assertEquals("4", d)
+            assertEquals("5", e)
+            assertEquals("6", f)
+            assertEquals(7, g)
+        }
+
+        assertEquals("(1, 2, 3, 4, 5, 6, 7)", septuple.toString())
+    }
+}

--- a/trikotFoundation/src/commonTest/kotlin/com/mirego/trikot/foundation/TuplesTest.kt
+++ b/trikotFoundation/src/commonTest/kotlin/com/mirego/trikot/foundation/TuplesTest.kt
@@ -15,7 +15,9 @@ class TuplesTest {
             assertEquals(4, d)
         }
 
-        assertEquals("(1, 2, 3, 4)", quadruple.toString())
+        val (a, b, c, d) = quadruple
+
+        assertEquals("($a, $b, $c, $d)", quadruple.toString())
     }
 
     @Test
@@ -30,7 +32,9 @@ class TuplesTest {
             assertEquals(5, e)
         }
 
-        assertEquals("(1, 2, 3, 4, 5)", quintuple.toString())
+        val (a, b, c, d, e) = quintuple
+
+        assertEquals("($a, $b, $c, $d, $e)", quintuple.toString())
     }
 
     @Test
@@ -46,7 +50,9 @@ class TuplesTest {
             assertEquals(6, f)
         }
 
-        assertEquals("(1, 2, 3, 4, 5, 6)", sextuple.toString())
+        val (a, b, c, d, e, f) = sextuple
+
+        assertEquals("($a, $b, $c, $d, $e, $f)", sextuple.toString())
     }
 
     @Test
@@ -63,6 +69,8 @@ class TuplesTest {
             assertEquals(7, g)
         }
 
-        assertEquals("(1, 2, 3, 4, 5, 6, 7)", septuple.toString())
+        val (a, b, c, d, e, f, g) = septuple
+
+        assertEquals("($a, $b, $c, $d, $e, $f, $g)", septuple.toString())
     }
 }

--- a/trikotFoundation/src/commonTest/kotlin/com/mirego/trikot/foundation/TuplesTest.kt
+++ b/trikotFoundation/src/commonTest/kotlin/com/mirego/trikot/foundation/TuplesTest.kt
@@ -73,4 +73,67 @@ class TuplesTest {
 
         assertEquals("($a, $b, $c, $d, $e, $f, $g)", septuple.toString())
     }
+
+    @Test
+    fun testOctuple() {
+        val octuple = Octuple("1", "2", "3", "4", "5", "6", "7", 8)
+
+        octuple.let { (a, b, c, d, e, f, g, h) ->
+            assertEquals("1", a)
+            assertEquals("2", b)
+            assertEquals("3", c)
+            assertEquals("4", d)
+            assertEquals("5", e)
+            assertEquals("6", f)
+            assertEquals("7", g)
+            assertEquals(8, h)
+        }
+
+        val (a, b, c, d, e, f, g, h) = octuple
+
+        assertEquals("($a, $b, $c, $d, $e, $f, $g, $h)", octuple.toString())
+    }
+
+    @Test
+    fun testNonuple() {
+        val nonuple = Nonuple("1", "2", "3", "4", "5", "6", "7", "8", 9)
+
+        nonuple.let { (a, b, c, d, e, f, g, h, i) ->
+            assertEquals("1", a)
+            assertEquals("2", b)
+            assertEquals("3", c)
+            assertEquals("4", d)
+            assertEquals("5", e)
+            assertEquals("6", f)
+            assertEquals("7", g)
+            assertEquals("8", h)
+            assertEquals(9, i)
+        }
+
+        val (a, b, c, d, e, f, g, h, i) = nonuple
+
+        assertEquals("($a, $b, $c, $d, $e, $f, $g, $h, $i)", nonuple.toString())
+    }
+
+    @Test
+    fun testDecuple() {
+        val decuple = Decuple("1", "2", "3", "4", "5", "6", "7", "8", "9", 10)
+
+        decuple.let { (a, b, c, d, e, f, g, h, i, j) ->
+            assertEquals("1", a)
+            assertEquals("2", b)
+            assertEquals("3", c)
+            assertEquals("4", d)
+            assertEquals("5", e)
+            assertEquals("6", f)
+            assertEquals("7", g)
+            assertEquals("8", h)
+            assertEquals("9", i)
+            assertEquals(10, j)
+        }
+
+        val (a, b, c, d, e, f, g, h, i, j) = decuple
+
+        assertEquals("($a, $b, $c, $d, $e, $f, $g, $h, $i, $j)", decuple.toString())
+    }
 }


### PR DESCRIPTION
## Description

Introduce tuples for 4, 5, 6, 7, 8, 9 and 10 items.

## Motivation and Context

Since kotlin only provides `Pair` and `Triple`, we introduce `Quadruple`, `Quintuple`, `Sextuple`, `Septuple`, `Octuple`, `Nonuple` and `Decuple` for an extended destructuring toolset. See associated unit tests for examples.

## How Has This Been Tested?
This has been tested in multiple multiplatform projects here at Mirego. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
