### PR TITLE
Fix issue with atomic reference returning wrong value when frozen

### DIFF
--- a/trikotFoundation/src/commonTest/kotlin/com/mirego/trikot/foundation/concurrent/AtomicReferenceTest.kt
+++ b/trikotFoundation/src/commonTest/kotlin/com/mirego/trikot/foundation/concurrent/AtomicReferenceTest.kt
@@ -1,0 +1,29 @@
+package com.mirego.trikot.foundation.concurrent
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class AtomicReferenceTest {
+    private val atomicReference = AtomicReference<String?>(null)
+    private val expectedValue = "expectedValue"
+
+    @Test
+    fun canSetNewNullValueAndReadAfterFreezing() {
+        atomicReference.compareAndSet(null, expectedValue)
+        assertEquals(expectedValue, atomicReference.value)
+        MrFreeze.freeze(atomicReference)
+        atomicReference.compareAndSet(expectedValue, null)
+        assertNull(atomicReference.value)
+    }
+
+    @Test
+    fun canSwapValue() {
+        assertEquals(expectedValue, atomicReference.compareAndSwap(null, expectedValue))
+        assertEquals(null, atomicReference.compareAndSwap(expectedValue, null))
+        freeze(atomicReference)
+        assertEquals(expectedValue, atomicReference.compareAndSwap(null, expectedValue))
+        assertEquals(expectedValue, atomicReference.compareAndSwap(null, "other"))
+        assertEquals("other", atomicReference.compareAndSwap(expectedValue, "other"))
+    }
+}

--- a/trikotFoundation/src/jvmShared/kotlin/com/mirego/trikot/foundation/concurrent/AtomicReference.kt
+++ b/trikotFoundation/src/jvmShared/kotlin/com/mirego/trikot/foundation/concurrent/AtomicReference.kt
@@ -24,7 +24,7 @@ actual class AtomicReference<T> actual constructor(value: T) {
         return if (compareAndSet(expected, new)) {
             new
         } else {
-            expected
+            internalRef.get()
         }
     }
 }


### PR DESCRIPTION
## Motivation and Context
A subtle issue can happen in our atomic reference deferred freezing implementation when setting back the value to null. If a value was set before the freezing and value was set to null after the freezing, the value getter was fallbacking to the unfrozen initial value.

More over, compare and swap (never used I guess) was returning the expected value instead of the current value when failing.

## How Has This Been Tested?
- Both issues has been unit tested (Failed before change, work after change)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)
