### PR TITLE
Add fractional seconds formatter for ISO8601 date

### DIFF
--- a/trikotFoundation/src/nativeMain/kotlin/com/mirego/trikot/foundation/date/Date.kt
+++ b/trikotFoundation/src/nativeMain/kotlin/com/mirego/trikot/foundation/date/Date.kt
@@ -1,5 +1,6 @@
 package com.mirego.trikot.foundation.date
 
+import kotlin.math.floor
 import kotlin.time.Duration
 import kotlin.time.ExperimentalTime
 import platform.Foundation.NSDate
@@ -9,7 +10,6 @@ import platform.Foundation.NSISO8601DateFormatter
 import platform.Foundation.dateByAddingTimeInterval
 import platform.Foundation.timeIntervalSince1970
 import platform.UIKit.UIDevice
-import kotlin.math.floor
 
 @ExperimentalTime
 actual class Date(val nsDate: NSDate) {

--- a/trikotFoundation/src/nativeMain/kotlin/com/mirego/trikot/foundation/date/Date.kt
+++ b/trikotFoundation/src/nativeMain/kotlin/com/mirego/trikot/foundation/date/Date.kt
@@ -3,9 +3,13 @@ package com.mirego.trikot.foundation.date
 import kotlin.time.Duration
 import kotlin.time.ExperimentalTime
 import platform.Foundation.NSDate
+import platform.Foundation.NSISO8601DateFormatWithFractionalSeconds
+import platform.Foundation.NSISO8601DateFormatWithInternetDateTime
 import platform.Foundation.NSISO8601DateFormatter
 import platform.Foundation.dateByAddingTimeInterval
 import platform.Foundation.timeIntervalSince1970
+import platform.UIKit.UIDevice
+import kotlin.math.floor
 
 @ExperimentalTime
 actual class Date(val nsDate: NSDate) {
@@ -27,17 +31,45 @@ actual class Date(val nsDate: NSDate) {
                 return Date(NSDate())
             }
 
+        @ExperimentalUnsignedTypes
         actual fun fromISO8601(isoDate: String): Date {
-            return Date(
-                NSISO8601DateFormatter().dateFromString(
-                    isoDate
-                ) ?: NSDate()
-            )
+            val systemVersion = UIDevice.currentDevice.systemVersion.toFloat()
+            return when {
+                floor(systemVersion) >= 11 ->
+                    getFormatterWithCorrespondingFormatOptions(isoDate)
+                        .dateFromString(isoDate)
+                else ->
+                    NSISO8601DateFormatter()
+                        .dateFromString(removeFractionalSeconds(isoDate))
+            }
+                ?.let(::Date)
+                ?: throw RuntimeException("Could not parse date $isoDate")
         }
 
         actual fun fromEpochMillis(epoch: Long): Date {
             return Date(NSDate(timeIntervalSinceReferenceDate = (epoch.toDouble() / 1000.0) - epochReferenceDateDelta))
         }
+
+        // NSISO8601DateFormatWithFractionalSeconds is iOS 11+
+        @ExperimentalUnsignedTypes
+        private fun getFormatterWithCorrespondingFormatOptions(date: String): NSISO8601DateFormatter =
+            when {
+                containsFractionalSeconds(date) -> NSISO8601DateFormatter().apply {
+                    formatOptions = NSISO8601DateFormatWithInternetDateTime
+                        .or(NSISO8601DateFormatWithFractionalSeconds)
+                }
+                else -> NSISO8601DateFormatter()
+            }
+
+        private fun removeFractionalSeconds(date: String): String =
+            with(date) {
+                when {
+                    containsFractionalSeconds(this) -> substringBeforeLast(".") + "Z"
+                    else -> this
+                }
+            }
+
+        private fun containsFractionalSeconds(date: String): Boolean = date.lastIndexOf(".") != -1
     }
 
     actual operator fun compareTo(other: Date): Int {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

The `Date::fromISO8601` function on iOS was returning the current date when the formatter was not able to format the string. It was easy to miss the error so now we throw an exception when it happens.

Also the default `NSISO8601DateFormatter` is pretty restrictive on the accepted string formats.

`2021-02-22T15:07:01.000Z` vs `2021-02-22T15:07:01Z`

Here's the strategy :

- If the version allows it (iOS 11+) **and** we have a string that contain milliseconds, we use a [formatter option](https://developer.apple.com/documentation/foundation/nsiso8601dateformatoptions/nsiso8601dateformatwithfractionalseconds?language=objc) that can handle it. But we can't just always return this new formatter option since it will throw an exception if the string does not contain milliseconds. So we return the default `NSISO8601DateFormatter` in that case.
- If we receive a string containing milliseconds on an old version of iOS (< 11), we remove the fractions and use the default `NSISO8601DateFormatter`

Notes : Android already support it.

## Motivation and Context
We are not error proof if the data is not always in the exact same format and it's easy not to realize there's a problem.

## How Has This Been Tested?
In our mobile app.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
