### PR TITLE
Use NSOrderedAscending to compare the current systemVersion on iOS

### DIFF
--- a/trikotFoundation/src/commonMain/kotlin/com/mirego/trikot/foundation/Tuples.kt
+++ b/trikotFoundation/src/commonMain/kotlin/com/mirego/trikot/foundation/Tuples.kt
@@ -168,7 +168,7 @@ data class Octuple<out A, out B, out C, out D, out E, out F, out G, out H>(
      * [fourth], [fifth], [sixth], [seventh] and [eighth] values.
      */
     override fun toString(): String = "($first, $second, $third, $fourth, $fifth, " +
-            "$sixth, $seventh, $eighth)"
+        "$sixth, $seventh, $eighth)"
 }
 
 /**
@@ -213,7 +213,7 @@ data class Nonuple<out A, out B, out C, out D, out E, out F, out G, out H, out I
      * [fourth], [fifth], [sixth], [seventh], [eighth] and [ninth] values.
      */
     override fun toString(): String = "($first, $second, $third, $fourth, $fifth, " +
-            "$sixth, $seventh, $eighth, $ninth)"
+        "$sixth, $seventh, $eighth, $ninth)"
 }
 
 /**
@@ -261,5 +261,5 @@ data class Decuple<out A, out B, out C, out D, out E, out F, out G, out H, out I
      * [fourth], [fifth], [sixth], [seventh], [eighth], [ninth] and [tenth] values.
      */
     override fun toString(): String = "($first, $second, $third, $fourth, $fifth, " +
-            "$sixth, $seventh, $eighth, $ninth, $tenth)"
+        "$sixth, $seventh, $eighth, $ninth, $tenth)"
 }

--- a/trikotFoundation/src/nativeMain/kotlin/com/mirego/trikot/foundation/date/Date.kt
+++ b/trikotFoundation/src/nativeMain/kotlin/com/mirego/trikot/foundation/date/Date.kt
@@ -4,10 +4,14 @@ import platform.Foundation.NSDate
 import platform.Foundation.NSISO8601DateFormatWithFractionalSeconds
 import platform.Foundation.NSISO8601DateFormatWithInternetDateTime
 import platform.Foundation.NSISO8601DateFormatter
+import platform.Foundation.NSNumericSearch
+import platform.Foundation.NSOrderedAscending
+import platform.Foundation.NSString
+import platform.Foundation.compare
+import platform.Foundation.create
 import platform.Foundation.dateByAddingTimeInterval
 import platform.Foundation.timeIntervalSince1970
 import platform.UIKit.UIDevice
-import kotlin.math.floor
 import kotlin.time.Duration
 import kotlin.time.ExperimentalTime
 
@@ -33,9 +37,8 @@ actual class Date(val nsDate: NSDate) {
 
         @ExperimentalUnsignedTypes
         actual fun fromISO8601(isoDate: String): Date {
-            val systemVersion = UIDevice.currentDevice.systemVersion.toFloat()
             return when {
-                floor(systemVersion) >= 11 ->
+                iosVersionGreaterThan(IOSVersion.IOS_11) ->
                     getFormatterWithCorrespondingFormatOptions(isoDate)
                         .dateFromString(isoDate)
                 else ->
@@ -70,6 +73,30 @@ actual class Date(val nsDate: NSDate) {
             }
 
         private fun containsFractionalSeconds(date: String): Boolean = date.lastIndexOf(".") != -1
+
+        private enum class IOSVersion {
+            IOS_10,
+            IOS_11,
+            IOS_12,
+            IOS_13,
+            IOS_14;
+
+            val stringValue: String
+                get() = when (this) {
+                    IOS_10 -> "10.0"
+                    IOS_11 -> "11.0"
+                    IOS_12 -> "12.0"
+                    IOS_13 -> "13.0"
+                    IOS_14 -> "14.0"
+                }
+        }
+
+        private fun iosVersionGreaterThan(version: IOSVersion): Boolean =
+            NSString.create(string = UIDevice.currentDevice.systemVersion)
+                .compare(
+                    string = version.stringValue,
+                    options = NSNumericSearch
+                ) != NSOrderedAscending
     }
 
     actual operator fun compareTo(other: Date): Int {


### PR DESCRIPTION
Use NSOrderedAscending to compare the current systemVersion with the minimal version. 
It was a mistake to assume that the version would always be a float.

## Motivation and Context
Fix a previously introduced breaking change. (#38)

## How Has This Been Tested?
In our mobile app with a version of iOS that is a patch version. (14.4.1)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
