### PR TITLE
Prevent memory corruption when converting NSData to ByteArray

### DIFF
--- a/trikotFoundation/src/iosArm32Main/kotlin/com/mirego/trikot/foundation/helpers/ByteArrayNativeUtils.kt
+++ b/trikotFoundation/src/iosArm32Main/kotlin/com/mirego/trikot/foundation/helpers/ByteArrayNativeUtils.kt
@@ -12,8 +12,10 @@ import platform.Foundation.create
 object ByteArrayNativeUtils {
     @ExperimentalUnsignedTypes
     fun convert(data: NSData): ByteArray {
-        val dataPointer: CPointer<ByteVar> = data.bytes!!.reinterpret()
-        return ByteArray(data.length.toInt()) { index -> dataPointer[index] }
+        return data.bytes?.let {
+            val dataPointer: CPointer<ByteVar> = it.reinterpret()
+            ByteArray(data.length.toInt()) { index -> dataPointer[index] }
+        } ?: ByteArray(0)
     }
     @ExperimentalUnsignedTypes
     fun convert(byteArray: ByteArray): NSData {

--- a/trikotFoundation/src/iosArm32Main/kotlin/com/mirego/trikot/foundation/helpers/ByteArrayNativeUtils.kt
+++ b/trikotFoundation/src/iosArm32Main/kotlin/com/mirego/trikot/foundation/helpers/ByteArrayNativeUtils.kt
@@ -1,22 +1,20 @@
 package com.mirego.trikot.foundation.helpers
 
+import kotlinx.cinterop.ByteVar
+import kotlinx.cinterop.CPointer
 import kotlinx.cinterop.addressOf
+import kotlinx.cinterop.get
+import kotlinx.cinterop.reinterpret
 import kotlinx.cinterop.usePinned
 import platform.Foundation.NSData
 import platform.Foundation.create
-import platform.posix.memcpy
 
 object ByteArrayNativeUtils {
     @ExperimentalUnsignedTypes
     fun convert(data: NSData): ByteArray {
-        val byteArray = ByteArray(data.length.toInt()).apply {
-            usePinned {
-                memcpy(it.addressOf(0), data.bytes, data.length)
-            }
-        }
-        return byteArray
+        val dataPointer: CPointer<ByteVar> = data.bytes!!.reinterpret()
+        return ByteArray(data.length.toInt()) { index -> dataPointer[index] }
     }
-
     @ExperimentalUnsignedTypes
     fun convert(byteArray: ByteArray): NSData {
         return byteArray.usePinned {

--- a/trikotFoundation/src/iosMain/kotlin/com/mirego/trikot/foundation/helpers/ByteArrayNativeUtils.kt
+++ b/trikotFoundation/src/iosMain/kotlin/com/mirego/trikot/foundation/helpers/ByteArrayNativeUtils.kt
@@ -12,8 +12,10 @@ import platform.Foundation.create
 object ByteArrayNativeUtils {
     @ExperimentalUnsignedTypes
     fun convert(data: NSData): ByteArray {
-        val dataPointer: CPointer<ByteVar> = data.bytes!!.reinterpret()
-        return ByteArray(data.length.toInt()) { index -> dataPointer[index] }
+        return data.bytes?.let {
+            val dataPointer: CPointer<ByteVar> = it.reinterpret()
+            ByteArray(data.length.toInt()) { index -> dataPointer[index] }
+        } ?: ByteArray(0)
     }
     @ExperimentalUnsignedTypes
     fun convert(byteArray: ByteArray): NSData {

--- a/trikotFoundation/src/iosMain/kotlin/com/mirego/trikot/foundation/helpers/ByteArrayNativeUtils.kt
+++ b/trikotFoundation/src/iosMain/kotlin/com/mirego/trikot/foundation/helpers/ByteArrayNativeUtils.kt
@@ -1,20 +1,19 @@
 package com.mirego.trikot.foundation.helpers
 
+import kotlinx.cinterop.ByteVar
+import kotlinx.cinterop.CPointer
 import kotlinx.cinterop.addressOf
+import kotlinx.cinterop.get
+import kotlinx.cinterop.reinterpret
 import kotlinx.cinterop.usePinned
 import platform.Foundation.NSData
 import platform.Foundation.create
-import platform.posix.memcpy
 
 object ByteArrayNativeUtils {
     @ExperimentalUnsignedTypes
     fun convert(data: NSData): ByteArray {
-        val byteArray = ByteArray(data.length.toInt()).apply {
-            usePinned {
-                memcpy(it.addressOf(0), data.bytes, data.length)
-            }
-        }
-        return byteArray
+        val dataPointer: CPointer<ByteVar> = data.bytes!!.reinterpret()
+        return ByteArray(data.length.toInt()) { index -> dataPointer[index] }
     }
     @ExperimentalUnsignedTypes
     fun convert(byteArray: ByteArray): NSData {


### PR DESCRIPTION
## Description
This PR changes the way we do NSData to ByteArray conversion by adopting the same technique used by the ktor iOS engine. It fixes memory corruptions in one of our application.

https://github.com/ktorio/ktor/blob/master/ktor-client/ktor-client-ios/darwin/src/io/ktor/client/engine/ios/IosUtils.kt

## Motivation and Context
We have a lot of weird memory corruptions crashes in our `Trikot` based apps. Looking into how Ktor was doing, the main difference is that it does not use `memcpy`. Adopting the same he same method that is used in a widely seems like the way to go

## How Has This Been Tested?
Preliminary results from an app where we are able to reproduce by spamming http requests is promising.
Spamming http request does not crash anymore in the specific project and we do not see any side effects

## Types of changes
- Bug fix (non-breaking change which fixes an issue)
