### PR TITLE
Reverted byte array conversion fix + optional handling

### DIFF
--- a/trikotFoundation/src/iosArm32Main/kotlin/com/mirego/trikot/foundation/helpers/ByteArrayNativeUtils.kt
+++ b/trikotFoundation/src/iosArm32Main/kotlin/com/mirego/trikot/foundation/helpers/ByteArrayNativeUtils.kt
@@ -9,12 +9,13 @@ import platform.posix.memcpy
 object ByteArrayNativeUtils {
     @ExperimentalUnsignedTypes
     fun convert(data: NSData): ByteArray {
-        val byteArray = ByteArray(data.length.toInt()).apply {
-            usePinned {
-                memcpy(it.addressOf(0), data.bytes, data.length)
+        return data.bytes?.let { bytes ->
+            ByteArray(data.length.toInt()).apply {
+                usePinned { pinned ->
+                    memcpy(pinned.addressOf(0), bytes, data.length)
+                }
             }
-        }
-        return byteArray
+        } ?: ByteArray(0)
     }
 
     @ExperimentalUnsignedTypes

--- a/trikotFoundation/src/iosArm32Main/kotlin/com/mirego/trikot/foundation/helpers/ByteArrayNativeUtils.kt
+++ b/trikotFoundation/src/iosArm32Main/kotlin/com/mirego/trikot/foundation/helpers/ByteArrayNativeUtils.kt
@@ -1,22 +1,22 @@
 package com.mirego.trikot.foundation.helpers
 
-import kotlinx.cinterop.ByteVar
-import kotlinx.cinterop.CPointer
 import kotlinx.cinterop.addressOf
-import kotlinx.cinterop.get
-import kotlinx.cinterop.reinterpret
 import kotlinx.cinterop.usePinned
 import platform.Foundation.NSData
 import platform.Foundation.create
+import platform.posix.memcpy
 
 object ByteArrayNativeUtils {
     @ExperimentalUnsignedTypes
     fun convert(data: NSData): ByteArray {
-        return data.bytes?.let {
-            val dataPointer: CPointer<ByteVar> = it.reinterpret()
-            ByteArray(data.length.toInt()) { index -> dataPointer[index] }
-        } ?: ByteArray(0)
+        val byteArray = ByteArray(data.length.toInt()).apply {
+            usePinned {
+                memcpy(it.addressOf(0), data.bytes, data.length)
+            }
+        }
+        return byteArray
     }
+
     @ExperimentalUnsignedTypes
     fun convert(byteArray: ByteArray): NSData {
         return byteArray.usePinned {

--- a/trikotFoundation/src/iosMain/kotlin/com/mirego/trikot/foundation/helpers/ByteArrayNativeUtils.kt
+++ b/trikotFoundation/src/iosMain/kotlin/com/mirego/trikot/foundation/helpers/ByteArrayNativeUtils.kt
@@ -9,13 +9,15 @@ import platform.posix.memcpy
 object ByteArrayNativeUtils {
     @ExperimentalUnsignedTypes
     fun convert(data: NSData): ByteArray {
-        val byteArray = ByteArray(data.length.toInt()).apply {
-            usePinned {
-                memcpy(it.addressOf(0), data.bytes, data.length)
+        return data.bytes?.let { bytes ->
+            ByteArray(data.length.toInt()).apply {
+                usePinned { pinned ->
+                    memcpy(pinned.addressOf(0), bytes, data.length)
+                }
             }
-        }
-        return byteArray
+        } ?: ByteArray(0)
     }
+
     @ExperimentalUnsignedTypes
     fun convert(byteArray: ByteArray): NSData {
         return byteArray.usePinned {

--- a/trikotFoundation/src/iosMain/kotlin/com/mirego/trikot/foundation/helpers/ByteArrayNativeUtils.kt
+++ b/trikotFoundation/src/iosMain/kotlin/com/mirego/trikot/foundation/helpers/ByteArrayNativeUtils.kt
@@ -1,21 +1,20 @@
 package com.mirego.trikot.foundation.helpers
 
-import kotlinx.cinterop.ByteVar
-import kotlinx.cinterop.CPointer
 import kotlinx.cinterop.addressOf
-import kotlinx.cinterop.get
-import kotlinx.cinterop.reinterpret
 import kotlinx.cinterop.usePinned
 import platform.Foundation.NSData
 import platform.Foundation.create
+import platform.posix.memcpy
 
 object ByteArrayNativeUtils {
     @ExperimentalUnsignedTypes
     fun convert(data: NSData): ByteArray {
-        return data.bytes?.let {
-            val dataPointer: CPointer<ByteVar> = it.reinterpret()
-            ByteArray(data.length.toInt()) { index -> dataPointer[index] }
-        } ?: ByteArray(0)
+        val byteArray = ByteArray(data.length.toInt()).apply {
+            usePinned {
+                memcpy(it.addressOf(0), data.bytes, data.length)
+            }
+        }
+        return byteArray
     }
     @ExperimentalUnsignedTypes
     fun convert(byteArray: ByteArray): NSData {


### PR DESCRIPTION
## Description
Revert changes to `ByteArrayNativeUtils` made in #41, the actual bug is in `trikot.http` (fix incoming)
Also took the opportunity to more clearly handle NSData.bytes optionality. 

Previous implementation did not seem to have problems with not checking if `data.bytes != nil` most probably because
`NSData.bytes` returns `nil` when `length == 0`. `memcpy` does nothing if you pass in 0 as number of bytes to copy.


## Motivation and Context
Revert a not need modification + make the code clearer

## How Has This Been Tested?
In an integrating application

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)