### PR TITLE
Use both javascript compilers to work in project that use legacy compilers

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -6,6 +6,5 @@ org.gradle.parallel=true
 org.gradle.configureondemand=true
 org.gradle.jvmargs=-Xmx3072m -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
 org.gradle.caching=true
-kotlin.js.compiler=ir
 kotlin.js.ir.dce=true
 kotlin.mpp.stability.nowarn=true

--- a/trikotFoundation/build.gradle.kts
+++ b/trikotFoundation/build.gradle.kts
@@ -25,7 +25,7 @@ kotlin {
     ios()
     iosArm32("iosArm32")
     tvos()
-    js(IR) {
+    js(BOTH) {
         browser()
     }
 


### PR DESCRIPTION
## Description
Support BOTH (IR and LEGACY) compilers

## Motivation and Context
Some projects use LEGACY Js compiler because IR compiler doesn't support enums. However, that prevented the usage of `trikot.foundation` since it couldn't resolve the dependency as legacy

Also removed the key in `gradle.properties` since it's overridden by `build.gradle.ts`

> The compiler type can also be set in the gradle.properties file, with the key kotlin.js.compiler=ir. This behaviour is overwritten by any settings in the build.gradle(.kts), however.
Source: https://kotlinlang.org/docs/js-ir-compiler.html

## How Has This Been Tested?
Couldn't resolve the dependency in a project, tested with a maven local version and it can now be resolved.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
